### PR TITLE
GH #16 candidate view

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,19 @@ module.exports = {
     'import/no-extraneous-dependencies': 'off',
     'prefer-promise-reject-errors': 'off',
 
+    /**
+     * Allow spaces for variable declarations
+     *
+     * @link https://eslint.org/docs/2.0.0/rules/no-multi-spaces
+     */
+    //'no-multi-spaces': [2, { exceptions: { "VariableDeclarator": true } }],
+
+    // allow all multi spaces
+    'no-multi-spaces': 'off',
+
     // allow debugger during development only
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+    'no-debugger':              process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-multiple-empty-lines':  process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'vue/no-unused-components': process.env.NODE_ENV === 'production' ? 'error' : 'off'
   }
 }

--- a/src/components/controls/asset-input.vue
+++ b/src/components/controls/asset-input.vue
@@ -9,6 +9,8 @@
       ref="quantity_input"
       @input="updateValueQuantity"
       :suffix="(allowed.length > 1) ? '': internalValue.symbol"
+      :max="max"
+      min=0
     />
     <q-select
       v-if="allowed.length > 1"
@@ -43,6 +45,9 @@ export default {
     },
     value: {
       type: Object
+    },
+    max: {
+      default: false
     }
   },
   data () {

--- a/src/components/controls/asset-input.vue
+++ b/src/components/controls/asset-input.vue
@@ -1,29 +1,38 @@
 <template>
-  <div class="row no-wrap">
+  <div class="row no-wrap q-gutter-sm">
     <q-input
-            class="full-width"
-            :label="label"
-            type="number"
-            color="primary"
-            v-model="internalValue.quantity"
-            ref="quantity_input"
-            @input="updateValueQuantity"
+      class="col"
+      :label="label"
+      type="number"
+      input-class = "text-right"
+      v-model="internalValue.quantity"
+      ref="quantity_input"
+      @input="updateValueQuantity"
     />
     <q-select
-            v-model="internalValue.symbol"
-            color="primary"
-            ref="symbol_input"
-            :options="
-                  allowed.map(c => {
-                    return { label: c.symbol, value: c };
-                  })
-                "
-            @input="updateValueAsset"
+      label = ""
+        v-model="internalValue.symbol"
+        color="primary"
+        ref="symbol_input"
+        :options="
+              allowed.map(c => {
+                return { label: c.symbol, value: c };
+              })
+            "
+        @input="updateValueAsset"
     />
   </div>
 </template>
 
 <script>
+/**
+ * Asset input shows an amount+token fields
+ *
+ * @todo Should this be in the components/ui as it's very simiar to components/ui/seconds-input.vue?
+ * @todo By default it shows EOS, even if it's not an allowed option.
+ * @todo Allow a max value.
+ * @todo Currency should not be a select if only one option is available
+ */
 export default {
   name: 'asset-input',
   props: {
@@ -83,9 +92,6 @@ export default {
       quantity = `${quantity.toFixed(symbol.precision)} ${symbol.symbol}`
 
       const value = { quantity, contract: symbol.contract }
-      console.log(`updating value`, value)
-      // this.value = value
-
       this.$emit('input', value)
     },
     parse (val) {

--- a/src/components/controls/asset-input.vue
+++ b/src/components/controls/asset-input.vue
@@ -8,18 +8,16 @@
       v-model="internalValue.quantity"
       ref="quantity_input"
       @input="updateValueQuantity"
+      :suffix="(allowed.length > 1) ? '': internalValue.symbol"
     />
     <q-select
+      v-if="allowed.length > 1"
       label = ""
-        v-model="internalValue.symbol"
-        color="primary"
-        ref="symbol_input"
-        :options="
-              allowed.map(c => {
-                return { label: c.symbol, value: c };
-              })
-            "
-        @input="updateValueAsset"
+      v-model="internalValue.symbol"
+      color="primary"
+      ref="symbol_input"
+      :options="allowed.map(c => { return { label: c.symbol, value: c } })"
+      @input="updateValueAsset"
     />
   </div>
 </template>
@@ -31,7 +29,6 @@
  * @todo Should this be in the components/ui as it's very simiar to components/ui/seconds-input.vue?
  * @todo By default it shows EOS, even if it's not an allowed option.
  * @todo Allow a max value.
- * @todo Currency should not be a select if only one option is available
  */
 export default {
   name: 'asset-input',

--- a/src/components/ui/seconds-input.vue
+++ b/src/components/ui/seconds-input.vue
@@ -1,29 +1,38 @@
 <template>
-  <div class="row no-wrap">
+  <div class="row no-wrap q-gutter-sm">
     <q-input
-            class="full-width"
-            :label="label"
-            type="number"
-            color="primary"
-            v-model="internalValue.quantity"
-            ref="quantity_input"
-            @input="updateValueQuantity"
+      class = "col"
+      :label ="label"
+      v-model ="internalValue.quantity"
+      type = "number"
+      input-class = "text-right"
+      ref = "quantity_input"
+      @input ="updateValueQuantity"
     />
     <q-select
-            v-model="internalValue.timeframe"
-            color="primary"
-            ref="timeframe_input"
-            :options="
-                  allowed.map(c => {
+      class = ""
+      v-model ="internalValue.timeframe"
+      label = ""
+      ref = "timeframe_input"
+      :options ="allowed.map(c => {
                     return { label: c, value: c };
-                  })
-                "
-            @input="updateValueTimeframe"
+                })"
+      @input="updateValueTimeframe"
     />
   </div>
 </template>
 
 <script>
+/**
+ * Seconds selector
+ *
+ * Timeframe should have a label defined as an empty string, or else, the
+ * selected value looks a bit shifted up, not aligning with the quantity
+ * input.
+ *
+ * @todo add option for weeks and months
+ * @todo Should this be in the components/controls as it's very simiar to components/controls/asset-input.vue?
+ */
 
 const oneMinute = 60
 const oneHour = oneMinute * 60
@@ -79,15 +88,12 @@ export default {
       return val
     },
     updateValueQuantity (val) {
-      // console.log(`updateValueQuantity`, val)
       let timeframeOpt = this.$refs.timeframe_input.value
       let timeframe
       if (typeof timeframeOpt === 'string') {
         timeframeOpt = this.$refs.timeframe_input.options.filter(o => o.label === this.$refs.timeframe_input.value)[0]
       }
       timeframe = timeframeOpt.value
-
-      console.log('timeframeOpt', timeframeOpt)
       let quantity = parseFloat(val)
 
       this.updateValue(quantity, timeframe)

--- a/src/components/ui/seconds-input.vue
+++ b/src/components/ui/seconds-input.vue
@@ -10,13 +10,10 @@
       @input ="updateValueQuantity"
     />
     <q-select
-      class = ""
       v-model ="internalValue.timeframe"
       label = ""
       ref = "timeframe_input"
-      :options ="allowed.map(c => {
-                    return { label: c, value: c };
-                })"
+      :options ="allowed.map(c => {return { label: c, value: c };})"
       @input="updateValueTimeframe"
     />
   </div>

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -6,7 +6,7 @@ a
   text-decoration: none
   color: $secondary
 
-// number imputs right aligned
+// number inputs right aligned
 input[type="number"]
   text-align: right
 

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -6,6 +6,10 @@ a
   text-decoration: none
   color: $secondary
 
+// number imputs right aligned
+input[type="number"]
+  text-align: right
+
 .inline-doc
   h1
     font-size: 3em

--- a/src/i18n/en_US/index.js
+++ b/src/i18n/en_US/index.js
@@ -515,6 +515,7 @@ export default {
     'general_max_votes': 'Max Votes',
     'general_lockup': 'Custodian Lockup',
     'general_max_req_pay': 'Maximum Requested Pay',
+    'general_max_req_pay_desc': 'Custodians can request payments every period. You can set a maximum payment amount and currency. By setting the currencty, all payments, including the ones for worker proposals) will be forced to be in this currency.',
     'general_lockup_release': 'Lockup Release Delay',
     'general_period_length': 'Period Length',
     'general_auth_high': 'High Threshold',

--- a/src/i18n/en_US/index.js
+++ b/src/i18n/en_US/index.js
@@ -488,7 +488,7 @@ export default {
     'no_payments': 'No payments due',
     'claim': 'claim',
     'update_requested_pay': 'Update Requested Pay',
-    'your_current_pay': 'Your current pay amount is set to {currentpay}',
+    'your_current_pay': 'Your current pay amount is set to {currentpay}. The max amount allowed is {max}.',
     'pay_invalid': 'Your current requested pay is invalid, you MUST update it before proceeding'
   },
 

--- a/src/pages/custodian/contracts-config.vue
+++ b/src/pages/custodian/contracts-config.vue
@@ -2,26 +2,31 @@
   <q-page class="q-pa-md">
 
     <div class="row q-col-gutter-md">
-      <div class="col-lg-2">
-        <q-tabs vertical v-model="selectedTab" class="text-secondary">
-          <q-tab name="general">{{$t('contracts_config.general')}}</q-tab>
-          <q-tab name="proposals" v-if="wpEnabled">{{$t('contracts_config.proposals')}}</q-tab>
-          <q-tab name="token">{{$t('contracts_config.token')}}</q-tab>
-          <q-tab name="referendum" v-if="referendumEnabled">{{$t('contracts_config.referendum')}}</q-tab>
-          <q-tab name="brand">{{$t('contracts_config.brand')}}</q-tab>
-          <q-tab name="features">{{$t('contracts_config.features')}}</q-tab>
-        </q-tabs>
-      </div>
-      <q-tab-panels class="col-lg-10" v-model="selectedTab">
+      <q-tabs vertical v-model="selectedTab" class="col-2 text-secondary">
+        <h5>&nbsp;</h5> <!-- spacer for tab titles -->
+        <q-tab name="general">{{$t('contracts_config.general')}}</q-tab>
+        <q-tab name="proposals" v-if="wpEnabled">{{$t('contracts_config.proposals')}}</q-tab>
+        <q-tab name="token">{{$t('contracts_config.token')}}</q-tab>
+        <q-tab name="referendum" v-if="referendumEnabled">{{$t('contracts_config.referendum')}}</q-tab>
+        <q-tab name="brand">{{$t('contracts_config.brand')}}</q-tab>
+        <q-tab name="features">{{$t('contracts_config.features')}}</q-tab>
+      </q-tabs>
+
+      <q-tab-panels class="col-10" v-model="selectedTab">
+
         <q-tab-panel name="general">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.general_title')}}</div>
+          <h5>{{$t('contracts_config.general_title')}}</h5>
+
           <!-- {{custodianConfig}} -->
           <q-card>
             <q-card-section>
               <q-input type="number" v-model="custodianConfig.numelected" :label="$t('contracts_config.general_number_elected')" />
               <q-input type="number" v-model="custodianConfig.maxvotes" :label="$t('contracts_config.general_max_votes')" />
               <asset-input :allowed="[dacToken, systemToken]" v-model="custodianConfig.lockupasset" :label="$t('contracts_config.general_lockup')" />
+
+              <p class="q-mt-md"> {{ $t('contracts_config.general_max_req_pay_desc')}} </p>
               <asset-input :allowed="[dacToken, systemToken]" v-model="custodianConfig.requested_pay_max" :label="$t('contracts_config.general_max_req_pay')" />
+
               <seconds-input v-model="custodianConfig.lockup_release_time_delay" :label="$t('contracts_config.general_lockup_release')" />
               <seconds-input v-model="custodianConfig.periodlength" :label="$t('contracts_config.general_period_length')" />
               <div class="row">
@@ -42,7 +47,7 @@
         </q-tab-panel>
 
         <q-tab-panel name="proposals" v-if="wpEnabled">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.proposals_title')}}</div>
+          <h5>{{$t('contracts_config.proposals_title')}}</h5>
           <!-- {{wpConfig}} -->
           <q-card v-if="wpConfigLoaded">
             <q-card-section>
@@ -57,7 +62,7 @@
         </q-tab-panel>
 
         <q-tab-panel name="token">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.token_title')}}</div>
+          <h5>{{$t('contracts_config.token_title')}}</h5>
 
           <!-- {{tokenConfig}} -->
           <q-card v-if="tokenConfigLoaded">
@@ -74,8 +79,8 @@
         </q-tab-panel>
 
         <q-tab-panel name="referendum" v-if="referendumEnabled">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.referendum_title')}}</div>
-<!--           {{referendumConfig}}-->
+          <h5>{{$t('contracts_config.referendum_title')}}</h5>
+          <!-- {{referendumConfig}} -->
           <q-card v-if="referendumConfigLoaded">
             <q-card-section>
               <seconds-input v-model="referendumConfig.duration" :label="$t('contracts_config.referendum_duration')" />
@@ -95,11 +100,10 @@
               <q-btn color="positive" :label="$t('contracts_config.propose_changes')" @click="startSave('referendum')" />
             </q-card-actions>
           </q-card>
-
         </q-tab-panel>
 
         <q-tab-panel name="brand">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.branding_title')}}</div>
+          <h5>{{$t('contracts_config.branding_title')}}</h5>
           <div class="row q-col-gutter-md" v-if="brandData">
             <div class="col-md-6">
               <q-card>
@@ -238,11 +242,10 @@
               </q-card>
             </div>
           </div>
-<!--            <div>{{brandData}}</div>-->
-
         </q-tab-panel>
+
         <q-tab-panel name="features">
-          <div class="text-h5 q-mb-md">{{$t('contracts_config.features_title')}}</div>
+          <h5>{{$t('contracts_config.features_title')}}</h5>
           <q-card>
             <q-card-section>
               <div class="row">
@@ -272,8 +275,8 @@
                 </q-card-actions>
             </q-card-section>
           </q-card>
-
         </q-tab-panel>
+
       </q-tab-panels>
     </div>
 
@@ -295,6 +298,17 @@
 </template>
 
 <script>
+/**
+ * DAC configuration stored on chain
+ *
+ * Different configuration stored on chain. The config values are grouped in
+ * tabs. The tab list is a col-3 because "job applications" fits in 2, but
+ * without space.
+ *
+ * @todo The tabs texts are centered, and they look weird. We need to left align them.
+ * @todo The tabs documentation has a grey border between the tabs and the right panel. I can't find how to set it.
+ * @todo Document what "Service Provider" is.
+ */
 import { mapActions, mapGetters } from 'vuex'
 import { colors } from 'quasar'
 import AssetInput from '../../components/controls/asset-input'

--- a/src/pages/custodian/dac-management.vue
+++ b/src/pages/custodian/dac-management.vue
@@ -1,6 +1,7 @@
 <template>
   <q-page class="q-pa-md">
-    <div class="text-h4">Manage DAC</div>
+    <h4>Manage DAC</h4>
+
     <q-tabs align="justify">
       <q-route-tab
         default

--- a/src/pages/custodian/my-payments.vue
+++ b/src/pages/custodian/my-payments.vue
@@ -49,7 +49,12 @@
 
           <q-card-section>
             <div class="q-pa-md">
-              <div>{{$t('mypayments.your_current_pay', { currentpay: getIsCandidate.requestedpay })}}</div>
+              <div>
+                {{$t('mypayments.your_current_pay', {
+                  currentpay: getIsCandidate.requestedpay,
+                  max: maxPaymentLabel
+                })}}
+              </div>
               <div class="text-negative" v-if="requestedPayInvalid"><strong>{{$t('mypayments.pay_invalid')}}</strong></div>
               <q-item class="q-pl-none">
                 <q-item-section avatar>
@@ -98,9 +103,11 @@ export default {
       newRequestedPay: null,
       requestedPayInvalid: false,
       dacToken: { symbol, precision, contract: this.$dir.symbol.contract, value: 0 },
-      allowed: []
+      allowed: [],
+      maxPaymentLabel: ''
     }
   },
+
   computed: {
     ...mapGetters({
       getCustodianConfig: 'dac/getCustodianConfig',
@@ -125,6 +132,7 @@ export default {
       )
     }
   },
+
   methods: {
     DueDateExpired (dueDate) {
       if (dueDate === undefined) {
@@ -228,12 +236,10 @@ export default {
     async getClaimPay () {
       this.loading = true
       this.pendingpay = await this.$store.dispatch('user/fetchPendingPay', this.getAccountName)
-      console.log('pendingpay', this.pendingpay)
       this.loading = false
     },
 
     splitAsset (asset) {
-      console.log(`Split ${asset.quantity}`, asset)
       const [qtyStr, symbolStr] = asset.quantity.split(' ')
       const [, precisionStr] = qtyStr.split('.')
       return {
@@ -244,19 +250,42 @@ export default {
       }
     }
   },
+
+  /**
+   * Loads the initial values
+   *
+   * There is an error, when loading this page as first page, account not found, see issue #33
+   *
+   * @todo fix user not detected on page load
+   */
   mounted () {
     this.getClaimPay()
-    this.newRequestedPay = this.getCustodianConfig.requested_pay_max
+    const maxPay     = this.getCustodianConfig.requested_pay_max // this is an object, with {quantity: the string, contract: the 12 chars contract"}
+    let   currentPay = this.getIsCandidate.requestedpay          // this is a string "$value $"
+
+    this.maxPaymentLabel = maxPay.quantity
+
+    this.newRequestedPay = {
+      contract: maxPay.contract,
+      quantity: this.getIsCandidate.requestedpay
+    }
+
+    /**
+     * Sets the allowed currencies
+     *
+     * Even if the DAC handles multipla currencies, my payments can only be
+     * requested in the currency set as max payment.
+     *
+     * @todo This should be encapsulated.
+     */
     this.allowed = [this.splitAsset(this.getCustodianConfig.requested_pay_max)]
+
     const [, newRequestedPaySymbol] = this.newRequestedPay.quantity.split(' ')
-    const currentPay = this.getIsCandidate.requestedpay
-    const [amountStr, symbol] = currentPay.split(' ')
+    const [, symbol] = currentPay.split(' ')
     if (symbol !== newRequestedPaySymbol) {
-      console.log(`${symbol} !== ${newRequestedPaySymbol} `, amountStr)
       this.requestedPayInvalid = true
       this.newRequestedPay.quantity = `0.0000 ${newRequestedPaySymbol}`
     }
-    console.log(currentPay, this.newRequestedPay)
   },
 
   validations () {

--- a/src/pages/custodian/my-payments.vue
+++ b/src/pages/custodian/my-payments.vue
@@ -62,7 +62,7 @@
                 </q-item-section>
 
                 <q-item-section>
-                  <asset-input :allowed="allowed" v-model="newRequestedPay" />
+                  <asset-input :allowed="allowed" v-model="newRequestedPay" :max="maxPaymentAmount" />
                 </q-item-section>
               </q-item>
             </div>
@@ -104,7 +104,8 @@ export default {
       requestedPayInvalid: false,
       dacToken: { symbol, precision, contract: this.$dir.symbol.contract, value: 0 },
       allowed: [],
-      maxPaymentLabel: ''
+      maxPaymentLabel: '',
+      maxPaymentAmount: ''
     }
   },
 
@@ -252,36 +253,30 @@ export default {
   },
 
   /**
-   * Loads the initial values
+   * Loads the initial values.
    *
-   * There is an error, when loading this page as first page, account not found, see issue #33
+   * Even if the DAC handles multiple currencies, my payments can only be
+   * requested in the currency set as max payment.
    *
-   * @todo fix user not detected on page load
+   * @todo fix user not detected on page load, see issue #33
    */
   mounted () {
     this.getClaimPay()
     const maxPay     = this.getCustodianConfig.requested_pay_max // this is an object, with {quantity: the string, contract: the 12 chars contract"}
     let   currentPay = this.getIsCandidate.requestedpay          // this is a string "$value $"
 
-    this.maxPaymentLabel = maxPay.quantity
+    this.maxPaymentLabel  = maxPay.quantity
+    this.maxPaymentAmount = maxPay.quantity.split(' ')[0]
 
     this.newRequestedPay = {
       contract: maxPay.contract,
       quantity: this.getIsCandidate.requestedpay
     }
 
-    /**
-     * Sets the allowed currencies
-     *
-     * Even if the DAC handles multipla currencies, my payments can only be
-     * requested in the currency set as max payment.
-     *
-     * @todo This should be encapsulated.
-     */
     this.allowed = [this.splitAsset(this.getCustodianConfig.requested_pay_max)]
 
-    const [, newRequestedPaySymbol] = this.newRequestedPay.quantity.split(' ')
-    const [, symbol] = currentPay.split(' ')
+    let newRequestedPaySymbol = this.newRequestedPay.quantity.split(' ')[1]
+    let symbol                = currentPay.split(' ')[1]
     if (symbol !== newRequestedPaySymbol) {
       this.requestedPayInvalid = true
       this.newRequestedPay.quantity = `0.0000 ${newRequestedPaySymbol}`

--- a/src/pages/custodian/my-payments.vue
+++ b/src/pages/custodian/my-payments.vue
@@ -49,12 +49,12 @@
 
           <q-card-section>
             <div class="q-pa-md">
-              <div>
+              <p>
                 {{$t('mypayments.your_current_pay', {
                   currentpay: getIsCandidate.requestedpay,
                   max: maxPaymentLabel
                 })}}
-              </div>
+              </p>
               <div class="text-negative" v-if="requestedPayInvalid"><strong>{{$t('mypayments.pay_invalid')}}</strong></div>
               <q-item class="q-pl-none">
                 <q-item-section avatar>

--- a/src/pages/manage-candidateship.vue
+++ b/src/pages/manage-candidateship.vue
@@ -33,6 +33,7 @@
 
           <q-separator spaced inset />
 
+          <!-- requested pay -->
           <q-item v-if="getEnableCustPayments" class="full-width">
             <q-item-section avatar>
               <q-icon name="icon-type-2" />
@@ -40,13 +41,19 @@
 
             <q-item-section>{{$t(`manage_candidateship.requestedpay`)}}</q-item-section>
 
-            <q-item-section style="white-space: nowrap">
+            <q-item-section style="white-space: nowrap" class="text-right">
               {{$helper.assetToLocaleNumber(getIsCandidate.requestedpay)}}
             </q-item-section>
+
+            <q-item-section style="white-space: nowrap">
+              <q-btn label="update" color="secondary" to="/custodian/my-payments" />
+            </q-item-section>
+
           </q-item>
 
           <q-separator spaced inset v-if="getEnableCustPayments" />
 
+          <!-- total votes -->
           <q-item class="full-width">
             <q-item-section avatar>
               <q-icon name="how_to_vote" />
@@ -54,12 +61,16 @@
 
             <q-item-section>{{$t(`manage_candidateship.total_votes`)}}</q-item-section>
 
-            <q-item-section>{{$helper.toLocaleNumber(getIsCandidate.total_votes / 10000)}}</q-item-section>
+            <q-item-section class="text-right">
+              {{$helper.assetSymbolToLocaleNumber(getIsCandidate.total_votes / 10000, $dir.symbol.symbol)}}
+            </q-item-section>
 
+            <!-- noop -->
+            <q-item-section style="white-space: nowrap"></q-item-section>
           </q-item>
-
           <q-separator spaced inset />
 
+          <!-- staked -->
           <q-item class="full-width">
             <q-item-section avatar>
               <q-icon name="icon-dac-balance" />
@@ -67,23 +78,23 @@
 
             <q-item-section>{{$t(`manage_candidateship.current_stake`)}}</q-item-section>
 
-            <q-item-section no-wrap>
-              <div class="row">
-                <div class="col-xs-6">{{$helper.assetSymbolToLocaleNumber(getStakedDacBalance, $dir.symbol.symbol)}}</div>
-                <div class="col-xs-4 q-pl-lg">
-                  <q-btn
-                          icon="add"
-                          round
-                          size="sm"
-                          title="Increase stake"
-                          color="primary"
-                          @click="increase_stake_modal = true"
-                  />
-                </div>
-              </div>
+            <q-item-section  class="text-right" no-wrap>
+              {{$helper.assetSymbolToLocaleNumber(getStakedDacBalance, $dir.symbol.symbol)}}
+            </q-item-section>
+
+            <q-item-section>
+              <q-btn
+                icon="add"
+                round
+                size="sm"
+                title="Increase stake"
+                color="primary"
+                @click="increase_stake_modal = true"
+              />
             </q-item-section>
 
           </q-item>
+
         </q-card-section>
         <!-- <div class="" style="bottom:-50%;right:-80%;"></div> -->
         <q-card-section class="full-width">
@@ -426,7 +437,6 @@ export default {
     },
 
     splitAsset (asset) {
-      console.log(`Split ${asset.quantity}`, asset)
       const [qtyStr, symbolStr] = asset.quantity.split(' ')
       const quantity = parseFloat(qtyStr)
       const [, precisionStr] = qtyStr.split('.')

--- a/src/pages/manage-candidateship.vue
+++ b/src/pages/manage-candidateship.vue
@@ -21,6 +21,7 @@
               </q-item-label>
             </q-item-section>
           </q-item>
+
           <q-item class="full-width">
             <q-item-section>
               {{
@@ -30,7 +31,6 @@
               }}
             </q-item-section>
           </q-item>
-
           <q-separator spaced inset />
 
           <!-- requested pay -->
@@ -50,25 +50,7 @@
             </q-item-section>
 
           </q-item>
-
           <q-separator spaced inset v-if="getEnableCustPayments" />
-
-          <!-- total votes -->
-          <q-item class="full-width">
-            <q-item-section avatar>
-              <q-icon name="how_to_vote" />
-            </q-item-section>
-
-            <q-item-section>{{$t(`manage_candidateship.total_votes`)}}</q-item-section>
-
-            <q-item-section class="text-right">
-              {{$helper.assetSymbolToLocaleNumber(getIsCandidate.total_votes / 10000, $dir.symbol.symbol)}}
-            </q-item-section>
-
-            <!-- noop -->
-            <q-item-section style="white-space: nowrap"></q-item-section>
-          </q-item>
-          <q-separator spaced inset />
 
           <!-- staked -->
           <q-item class="full-width">
@@ -94,6 +76,24 @@
             </q-item-section>
 
           </q-item>
+          <q-separator spaced inset v-if="getEnableCustPayments" />
+
+          <!-- total votes -->
+          <q-item class="full-width">
+            <q-item-section avatar>
+              <q-icon name="how_to_vote" />
+            </q-item-section>
+
+            <q-item-section>{{$t(`manage_candidateship.total_votes`)}}</q-item-section>
+
+            <q-item-section class="text-right">
+              {{$helper.assetSymbolToLocaleNumber(getIsCandidate.total_votes / 10000, $dir.symbol.symbol)}}
+            </q-item-section>
+
+            <!-- noop -->
+            <q-item-section style="white-space: nowrap"></q-item-section>
+          </q-item>
+          <q-separator spaced inset />
 
         </q-card-section>
         <!-- <div class="" style="bottom:-50%;right:-80%;"></div> -->
@@ -260,6 +260,11 @@
 </template>
 
 <script>
+/**
+ * Manage my candidateship view
+ *
+ * @todo, this view can be merged with my payments
+ */
 import { mapGetters } from 'vuex'
 import ProfilePic from '../components/ui/profile-pic'
 import AssetInput from '../components/controls/asset-input'

--- a/src/pages/member/new-worker-proposal.vue
+++ b/src/pages/member/new-worker-proposal.vue
@@ -18,22 +18,25 @@
                     v-model="wp_data.title"
                   />
         </div>
+
+        <!-- Category -->
         <div class="col-xs-12 col-lg-4">
             <q-select
-                    :error="$v.wp_data.category.$error"
-                    :error-label="$t('newworkerproposal.select_category')"
-              color="primary"
-              v-model="wp_data.category"
               :label="$t('newworkerproposal.proposal_category')"
-              emit-value
+              v-model="wp_data.category"
               :options="getWpCategoriesOptions"
+              emit-value
+              map-options
+              :error="$v.wp_data.category.$error"
+              :error-label="$t('newworkerproposal.select_category')"
             />
         </div>
+
         <div class="col-xs-12 col-lg-6">
-
           <asset-input :allowed="allowed_currencies" :label="$t('newworkerproposal.pay_amount')" v-model="wp_data.pay_amount" />
-
         </div>
+
+        <!-- arbitrator -->
         <div class="col-xs-12 col-lg-6">
           <q-input
                   class="full-width"
@@ -42,6 +45,8 @@
                   color="primary"
                   v-model="wp_data.arbitrator" />
         </div>
+
+        <!-- expected duration -->
         <div class="col-xs-12">
           <seconds-input v-model="wp_data.job_duration" :label="$t('newworkerproposal.expected_duration')" />
         </div>


### PR DESCRIPTION
Fixes #16 

- <asset-input> with max value, improved style, no dropdown for symbol/currency if only a single currency is available
- <seconds-input> improved style
- input type=number right aligned
- translations for max-payment descriptions
- improve view to edit contract flags
- fixes issue loading right value for my-payments default value
- improves my candidateship view
- more flexible rules for elint to make code easier to read